### PR TITLE
direct copy reader doc to writer

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -205,10 +205,8 @@ def decrypt_file(src, dest):
     input_.SetFileKey(file_key)
     input_.strict = False
     print("[Log] 文件 {} 共 {} 页.".format(src, input_.getNumPages()))
-    for i in range(input_.getNumPages()):
-        print(".", end="", flush=True)
-        output.addPage(input_.getPage(i))
-    print("\n[Log] 写入文件")
+    output.cloneReaderDocumentRoot(input_)
+    print("[Log] 写入文件")
     outputStream = open(dest, "wb")
     output.write(outputStream)
     temp_fp.close()


### PR DESCRIPTION
不再逐页复制文档，而是直接将解密后的 PDF 文档复制到新建的 PDF 。
这样可以将目录和书签一起复制，以解决 #5 中的无法用 `input_.outlines` 获取大纲的问题。